### PR TITLE
Support running tests on php70

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,18 +12,15 @@ jobs:
 
   phpunit-test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
-    name: PHP ${{ matrix.php-versions }} Test
     steps:
       - uses: actions/checkout@v2
 
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: 7.4
           extensions: dom, mbstring
+          coverage: pcov
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -51,4 +48,9 @@ jobs:
       - name: Run test suite
         run: |
           mkdir -p build/logs
-          ./vendor/bin/phpunit
+          ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
+
+      - name: Send to Coveralls
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ./vendor/bin/php-coveralls -v

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -22,7 +22,7 @@ jobs:
           php-version: 7.4
           extensions: dom, mbstring
           coverage: none
-          tools: cs2pr
+          tools: cs2pr, phpcs
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -39,4 +39,4 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run phpcs
-        run: vendor/bin/phpcs --standard=./phpcs.xml --report=checkstyle -q ./src ./tests | cs2pr
+        run: phpcs --standard=./phpcs.xml --report=checkstyle -q ./src ./tests | cs2pr

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -11,15 +11,18 @@ on:
 jobs:
 
   phpunit-test:
-    name: phpunit test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-versions: ['7.0', '7.1', '7.2', '7.3', '7.4']
+    name: PHP ${{ matrix.php-versions }} Test
     steps:
       - uses: actions/checkout@v2
 
       - name: Setup PHP Action
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: ${{ matrix.php-versions }}
           extensions: dom, mbstring
           coverage: pcov
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Run test suite
         run: |
           mkdir -p build/logs
-          ./vendor/bin/phpunit --do-not-cache-result --coverage-clover build/logs/clover.xml
+          ./vendor/bin/phpunit --coverage-clover build/logs/clover.xml
 
       - name: Send to Coveralls
         env:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -22,6 +22,7 @@ jobs:
           php-version: 7.4
           extensions: dom, mbstring
           coverage: none
+          tools: psalm
 
       - name: Get Composer Cache Directory
         id: composer-cache
@@ -44,4 +45,4 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Run psalm
-        run: ./vendor/bin/psalm --shepherd --show-info=true --diff --diff-methods --output-format=github
+        run: psalm --shepherd --show-info=true --diff --diff-methods --output-format=github

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,10 @@
     }
   ],
   "require": {
-    "php": "^7.4 || ^8.0"
+    "php": "^7.0 || ^8.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0",
-    "vimeo/psalm": "^3.12",
-    "squizlabs/php_codesniffer": "^3.5",
     "twinh/php-coveralls": "^2.3"
   },
   "autoload": {

--- a/tests/PhpCast/CastTest.php
+++ b/tests/PhpCast/CastTest.php
@@ -22,7 +22,7 @@ use TypeError;
 
 class CastTest extends TestCase
 {
-    public function testToInt(): void
+    public function testToInt()
     {
         $this->assertSame(0, Cast::toInt(0));
         $this->assertSame(1, Cast::toInt(1));
@@ -35,30 +35,52 @@ class CastTest extends TestCase
         $this->assertSame(0, Cast::toInt(false));
         $this->assertSame(1, Cast::toInt(true));
 
-        $this->assertTypeError(fn () => Cast::toInt(''));
-        $this->assertTypeError(fn () => Cast::toInt('a'));
-        $this->assertTypeError(fn () => Cast::toInt('ok'));
-        $this->assertTypeError(fn () => Cast::toInt('true'));
-        $this->assertTypeError(fn () => Cast::toInt('null'));
-        $this->assertTypeError(fn () => Cast::toInt(null));
-        $this->assertTypeError(fn () => Cast::toInt([]));
-        $this->assertTypeError(fn () => Cast::toInt((object)[]));
-        $this->assertTypeError(fn () => Cast::toInt(PHP_INT_MAX + 1));
-        $this->assertTypeError(fn () => Cast::toInt(-9223372036854776833));
+        $this->assertTypeError(function () {
+            return Cast::toInt('');
+        });
+        $this->assertTypeError(function () {
+            return Cast::toInt('a');
+        });
+        $this->assertTypeError(function () {
+            return Cast::toInt('ok');
+        });
+        $this->assertTypeError(function () {
+            return Cast::toInt('true');
+        });
+        $this->assertTypeError(function () {
+            return Cast::toInt('null');
+        });
+        $this->assertTypeError(function () {
+            return Cast::toInt(null);
+        });
+        $this->assertTypeError(function () {
+            return Cast::toInt([]);
+        });
+        $this->assertTypeError(function () {
+            return Cast::toInt((object)[]);
+        });
+        $this->assertTypeError(function () {
+            return Cast::toInt(PHP_INT_MAX + 1);
+        });
+        $this->assertTypeError(function () {
+            return Cast::toInt(-9223372036854776833);
+        });
 
         try {
             Cast::toInt('123abc');
         } catch (\Throwable $e) {
         }
-        $this->assertTrue(isset($e));
-        $this->assertInstanceOf(TypeError::class, $e);
-        $this->assertInstanceOf(Exception::class, $e->getPrevious());
-        $this->assertSame('A non well formed numeric value encountered', $e->getPrevious()->getMessage());
+        if (version_compare(PHP_VERSION, '7.1.0') >= 0) {
+            $this->assertTrue(isset($e));
+            $this->assertInstanceOf(TypeError::class, $e);
+            $this->assertInstanceOf(Exception::class, $e->getPrevious());
+            $this->assertSame('A non well formed numeric value encountered', $e->getPrevious()->getMessage());
+        }
         $result = @Cast::toInt('123abc');
         $this->assertSame(123, $result);
     }
 
-    public function testToFloat(): void
+    public function testToFloat()
     {
         $this->assertSame(0.0, Cast::toFloat(0));
         $this->assertSame(1.0, Cast::toFloat(1));
@@ -73,17 +95,33 @@ class CastTest extends TestCase
         $this->assertSame(PHP_INT_MAX + 1, Cast::toFloat(PHP_INT_MAX + 1));
         $this->assertSame(-9223372036854776833, Cast::toFloat(-9223372036854776833));
 
-        $this->assertTypeError(fn () => Cast::toFloat(''));
-        $this->assertTypeError(fn () => Cast::toFloat('a'));
-        $this->assertTypeError(fn () => Cast::toFloat('ok'));
-        $this->assertTypeError(fn () => Cast::toFloat('true'));
-        $this->assertTypeError(fn () => Cast::toFloat('null'));
-        $this->assertTypeError(fn () => Cast::toFloat(null));
-        $this->assertTypeError(fn () => Cast::toFloat([]));
-        $this->assertTypeError(fn () => Cast::toFloat((object)[]));
+        $this->assertTypeError(function () {
+            return Cast::toFloat('');
+        });
+        $this->assertTypeError(function () {
+            return Cast::toFloat('a');
+        });
+        $this->assertTypeError(function () {
+            return Cast::toFloat('ok');
+        });
+        $this->assertTypeError(function () {
+            return Cast::toFloat('true');
+        });
+        $this->assertTypeError(function () {
+            return Cast::toFloat('null');
+        });
+        $this->assertTypeError(function () {
+            return Cast::toFloat(null);
+        });
+        $this->assertTypeError(function () {
+            return Cast::toFloat([]);
+        });
+        $this->assertTypeError(function () {
+            return Cast::toFloat((object)[]);
+        });
     }
 
-    public function testToString(): void
+    public function testToString()
     {
         $this->assertSame('0', Cast::toString(0));
         $this->assertSame('1', Cast::toString(1));
@@ -106,12 +144,18 @@ class CastTest extends TestCase
             )
         );
 
-        $this->assertTypeError(fn () => Cast::toString(null));
-        $this->assertTypeError(fn () => Cast::toString([]));
-        $this->assertTypeError(fn () => Cast::toString((object)[]));
+        $this->assertTypeError(function () {
+            return Cast::toString(null);
+        });
+        $this->assertTypeError(function () {
+            return Cast::toString([]);
+        });
+        $this->assertTypeError(function () {
+            return Cast::toString((object)[]);
+        });
     }
 
-    public function testToBool(): void
+    public function testToBool()
     {
         $this->assertFalse(Cast::toBool(0));
         $this->assertTrue(Cast::toBool(1));
@@ -130,12 +174,18 @@ class CastTest extends TestCase
         $this->assertTrue(Cast::toBool('true'));
         $this->assertTrue(Cast::toBool('null'));
 
-        $this->assertTypeError(fn () => Cast::toBool(null));
-        $this->assertTypeError(fn () => Cast::toBool([]));
-        $this->assertTypeError(fn () => Cast::toBool((object)[]));
+        $this->assertTypeError(function () {
+            return Cast::toBool(null);
+        });
+        $this->assertTypeError(function () {
+            return Cast::toBool([]);
+        });
+        $this->assertTypeError(function () {
+            return Cast::toBool((object)[]);
+        });
     }
 
-    private function assertTypeError(callable $func): void
+    private function assertTypeError(callable $func)
     {
         try {
             $func();

--- a/tests/PhpCast/CastTest.php
+++ b/tests/PhpCast/CastTest.php
@@ -80,9 +80,6 @@ class CastTest extends TestCase
                 $this->assertInstanceOf(Exception::class, $e);
                 $this->assertSame('A non well formed numeric value encountered', $e->getMessage());
             }
-            $this->assertInstanceOf(TypeError::class, $e);
-            $this->assertInstanceOf(Exception::class, $e->getPrevious());
-            $this->assertSame('A non well formed numeric value encountered', $e->getPrevious()->getMessage());
         }
         $result = @Cast::toInt('123abc');
         $this->assertSame(123, $result);

--- a/tests/PhpCast/CastTest.php
+++ b/tests/PhpCast/CastTest.php
@@ -72,6 +72,14 @@ class CastTest extends TestCase
         }
         if (version_compare(PHP_VERSION, '7.1.0') >= 0) {
             $this->assertTrue(isset($e));
+            if (version_compare(PHP_VERSION, '7.4.0') >= 0) {
+                $this->assertInstanceOf(TypeError::class, $e);
+                $this->assertInstanceOf(Exception::class, $e->getPrevious());
+                $this->assertSame('A non well formed numeric value encountered', $e->getPrevious()->getMessage());
+            } else {
+                $this->assertInstanceOf(Exception::class, $e);
+                $this->assertSame('A non well formed numeric value encountered', $e->getMessage());
+            }
             $this->assertInstanceOf(TypeError::class, $e);
             $this->assertInstanceOf(Exception::class, $e->getPrevious());
             $this->assertSame('A non well formed numeric value encountered', $e->getPrevious()->getMessage());

--- a/tests/PhpCast/NullableCastTest.php
+++ b/tests/PhpCast/NullableCastTest.php
@@ -70,9 +70,14 @@ class NullableCastTest extends TestCase
         }
         if (version_compare(PHP_VERSION, '7.1.0') >= 0) {
             $this->assertTrue(isset($e));
-            $this->assertInstanceOf(TypeError::class, $e);
-            $this->assertInstanceOf(Exception::class, $e->getPrevious());
-            $this->assertSame('A non well formed numeric value encountered', $e->getPrevious()->getMessage());
+            if (version_compare(PHP_VERSION, '7.4.0') >= 0) {
+                $this->assertInstanceOf(TypeError::class, $e);
+                $this->assertInstanceOf(Exception::class, $e->getPrevious());
+                $this->assertSame('A non well formed numeric value encountered', $e->getPrevious()->getMessage());
+            } else {
+                $this->assertInstanceOf(Exception::class, $e);
+                $this->assertSame('A non well formed numeric value encountered', $e->getMessage());
+            }
         }
         $result = @NullableCast::toInt('123abc');
         $this->assertSame(123, $result);

--- a/tests/PhpCast/NullableCastTest.php
+++ b/tests/PhpCast/NullableCastTest.php
@@ -22,7 +22,7 @@ use TypeError;
 
 class NullableCastTest extends TestCase
 {
-    public function testToInt(): void
+    public function testToInt()
     {
         $this->assertNull(NullableCast::toInt(null));
         $this->assertSame(0, NullableCast::toInt(0));
@@ -36,29 +36,49 @@ class NullableCastTest extends TestCase
         $this->assertSame(0, NullableCast::toInt(false));
         $this->assertSame(1, NullableCast::toInt(true));
 
-        $this->assertTypeError(fn () => NullableCast::toInt(''));
-        $this->assertTypeError(fn () => NullableCast::toInt('a'));
-        $this->assertTypeError(fn () => NullableCast::toInt('ok'));
-        $this->assertTypeError(fn () => NullableCast::toInt('true'));
-        $this->assertTypeError(fn () => NullableCast::toInt('null'));
-        $this->assertTypeError(fn () => NullableCast::toInt([]));
-        $this->assertTypeError(fn () => NullableCast::toInt((object)[]));
-        $this->assertTypeError(fn () => NullableCast::toInt(PHP_INT_MAX + 1));
-        $this->assertTypeError(fn () => NullableCast::toInt(-9223372036854776833));
+        $this->assertTypeError(function () {
+            return NullableCast::toInt('');
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toInt('a');
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toInt('ok');
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toInt('true');
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toInt('null');
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toInt([]);
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toInt((object)[]);
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toInt(PHP_INT_MAX + 1);
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toInt(-9223372036854776833);
+        });
 
         try {
             NullableCast::toInt('123abc');
         } catch (\Throwable $e) {
         }
-        $this->assertTrue(isset($e));
-        $this->assertInstanceOf(TypeError::class, $e);
-        $this->assertInstanceOf(Exception::class, $e->getPrevious());
-        $this->assertSame('A non well formed numeric value encountered', $e->getPrevious()->getMessage());
+        if (version_compare(PHP_VERSION, '7.1.0') >= 0) {
+            $this->assertTrue(isset($e));
+            $this->assertInstanceOf(TypeError::class, $e);
+            $this->assertInstanceOf(Exception::class, $e->getPrevious());
+            $this->assertSame('A non well formed numeric value encountered', $e->getPrevious()->getMessage());
+        }
         $result = @NullableCast::toInt('123abc');
         $this->assertSame(123, $result);
     }
 
-    public function testToFloat(): void
+    public function testToFloat()
     {
         $this->assertNull(NullableCast::toFloat(null));
         $this->assertSame(0.0, NullableCast::toFloat(0));
@@ -74,16 +94,30 @@ class NullableCastTest extends TestCase
         $this->assertSame(PHP_INT_MAX + 1, NullableCast::toFloat(PHP_INT_MAX + 1));
         $this->assertSame(-9223372036854776833, NullableCast::toFloat(-9223372036854776833));
 
-        $this->assertTypeError(fn () => NullableCast::toFloat(''));
-        $this->assertTypeError(fn () => NullableCast::toFloat('a'));
-        $this->assertTypeError(fn () => NullableCast::toFloat('ok'));
-        $this->assertTypeError(fn () => NullableCast::toFloat('true'));
-        $this->assertTypeError(fn () => NullableCast::toFloat('null'));
-        $this->assertTypeError(fn () => NullableCast::toFloat([]));
-        $this->assertTypeError(fn () => NullableCast::toFloat((object)[]));
+        $this->assertTypeError(function () {
+            return NullableCast::toFloat('');
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toFloat('a');
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toFloat('ok');
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toFloat('true');
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toFloat('null');
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toFloat([]);
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toFloat((object)[]);
+        });
     }
 
-    public function testToString(): void
+    public function testToString()
     {
         $this->assertNull(NullableCast::toString(null));
         $this->assertSame('0', NullableCast::toString(0));
@@ -107,11 +141,15 @@ class NullableCastTest extends TestCase
             )
         );
 
-        $this->assertTypeError(fn () => NullableCast::toString([]));
-        $this->assertTypeError(fn () => NullableCast::toString((object)[]));
+        $this->assertTypeError(function () {
+            return NullableCast::toString([]);
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toString((object)[]);
+        });
     }
 
-    public function testToBool(): void
+    public function testToBool()
     {
         $this->assertNull(NullableCast::toBool(null));
         $this->assertFalse(NullableCast::toBool(0));
@@ -131,11 +169,15 @@ class NullableCastTest extends TestCase
         $this->assertTrue(NullableCast::toBool('true'));
         $this->assertTrue(NullableCast::toBool('null'));
 
-        $this->assertTypeError(fn () => NullableCast::toBool([]));
-        $this->assertTypeError(fn () => NullableCast::toBool((object)[]));
+        $this->assertTypeError(function () {
+            return NullableCast::toBool([]);
+        });
+        $this->assertTypeError(function () {
+            return NullableCast::toBool((object)[]);
+        });
     }
 
-    private function assertTypeError(callable $func): void
+    private function assertTypeError(callable $func)
     {
         try {
             $func();


### PR DESCRIPTION
- modify tests to run on PHP 7.0+
- remove phpcs and psalm from require-dev and change to use tools in shivammathur/setup-php at CI
- separate coverage reports to another workflow